### PR TITLE
Preliminary support for Visual Studio 2022

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/vcpkg"]
-	path = external/vcpkg
-	url = https://github.com/Microsoft/vcpkg.git
 [submodule "external/imgui_club"]
 	path = external/imgui_club
 	url = https://github.com/ocornut/imgui_club.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ include_directories(src)
 include_directories(external)
 
 # vcpkg setup
-set(VCPKG_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/external/vcpkg")
-set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+set(VCPKG_ROOT "$C:/vcpkg")
+set(CMAKE_TOOLCHAIN_FILE "C:/vcpkg/scripts/buildsystems/vcpkg.cmake")
 
 # Project definition
 project(pctation VERSION 0.1

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -17,6 +17,7 @@
 #pragma warning(default : 4251)
 #include <SDL2/SDL.h>
 #include <imgui.h>
+#include <SDL_syswm.h>
 #include <imgui_sdl2_gl3_backend/imgui_impl_opengl3.h>
 #include <imgui_sdl2_gl3_backend/imgui_impl_sdl.h>
 
@@ -71,7 +72,7 @@ void init_theme() {
   style.Colors[ImGuiCol_Text] = TXT(0.78f);
   style.Colors[ImGuiCol_TextDisabled] = TXT(0.28f);
   style.Colors[ImGuiCol_WindowBg] = ImVec4(0.13f, 0.14f, 0.17f, 1.00f);
-  style.Colors[ImGuiCol_ChildWindowBg] = BG(0.58f);
+  style.Colors[ImGuiCol_ChildBg] = BG(0.58f);
   style.Colors[ImGuiCol_PopupBg] = BG(0.9f);
   style.Colors[ImGuiCol_Border] = ImVec4(0.31f, 0.31f, 1.00f, 0.00f);
   style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
@@ -95,9 +96,9 @@ void init_theme() {
   style.Colors[ImGuiCol_Header] = MED(0.76f);
   style.Colors[ImGuiCol_HeaderHovered] = MED(0.86f);
   style.Colors[ImGuiCol_HeaderActive] = HI(1.00f);
-  style.Colors[ImGuiCol_Column] = ImVec4(0.14f, 0.16f, 0.19f, 1.00f);
-  style.Colors[ImGuiCol_ColumnHovered] = MED(0.78f);
-  style.Colors[ImGuiCol_ColumnActive] = MED(1.00f);
+  style.Colors[ImGuiCol_Separator] = ImVec4(0.14f, 0.16f, 0.19f, 1.00f);
+  style.Colors[ImGuiCol_SeparatorHovered] = MED(0.78f);
+  style.Colors[ImGuiCol_SeparatorActive] = MED(1.00f);
   style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.47f, 0.77f, 0.83f, 0.04f);
   style.Colors[ImGuiCol_ResizeGripHovered] = MED(0.78f);
   style.Colors[ImGuiCol_ResizeGripActive] = MED(1.00f);
@@ -106,7 +107,7 @@ void init_theme() {
   style.Colors[ImGuiCol_PlotHistogram] = TXT(0.63f);
   style.Colors[ImGuiCol_PlotHistogramHovered] = MED(1.00f);
   style.Colors[ImGuiCol_TextSelectedBg] = MED(0.43f);
-  style.Colors[ImGuiCol_ModalWindowDarkening] = BG(0.73f);
+  style.Colors[ImGuiCol_ModalWindowDimBg] = BG(0.73f);
 
   style.WindowPadding = ImVec2(6, 4);
   style.WindowRounding = 0.0f;
@@ -475,7 +476,7 @@ void Gui::draw_window_log(const char* title,
   ImGui::TextUnformatted(text_contents);
 
   if (should_autoscroll)
-    ImGui::SetScrollHere(1.0f);
+    ImGui::SetScrollHereY(1.0f);
   ImGui::EndChild();
 
   ImGui::End();
@@ -934,7 +935,7 @@ void Gui::draw_window_ram(const std::array<byte, RamSize>& ram_data) {
   // Window style
   ImGui::SetNextWindowSize(ImVec2(500, 411), ImGuiCond_FirstUseEver);
 
-  m_ram_memeditor.DrawWindow("RAM Contents", (MemoryEditor::u8*)ram_data.data(), RamSize, 0);
+  m_ram_memeditor.DrawWindow("RAM Contents", (ImU8*)ram_data.data(), RamSize, 0);
 }
 
 struct RegisterTableEntry {

--- a/src/renderer/CMakeLists.txt
+++ b/src/renderer/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(renderer STATIC rasterizer.cpp
                             shaders/screen.vs.glsl)
 
 target_link_libraries(renderer PUBLIC util)
-target_link_libraries(renderer PRIVATE SDL2::SDL2 glbinding::glbinding imgui::imgui gpu glm)
+target_link_libraries(renderer PRIVATE SDL2::SDL2 glbinding::glbinding imgui::imgui gpu)
 
 add_custom_command(
     TARGET renderer

--- a/src/renderer/screen_renderer.cpp
+++ b/src/renderer/screen_renderer.cpp
@@ -4,6 +4,8 @@
 
 #include <glbinding/gl/gl.h>
 
+#include <stdexcept>
+
 using namespace gl;
 
 namespace renderer {

--- a/src/util/fs.hpp
+++ b/src/util/fs.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifdef _MSC_VER
 #include <filesystem>
-#else
-#include <experimental/filesystem>
-#endif
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;


### PR DESCRIPTION
This is my small contribution to the project, not really a C++ pro so you may want to adjust a few things!

I have been able to fix and get the project to build by generating an .sln file using cmake-gui.

- std::experimental namespace isn't needed anymore
- some imgui members [have been renamed](https://github.com/ocornut/imgui/blob/master/docs/CHANGELOG.txt)
- some includes are apparently needed now
- glm doesn't have to be linked as it's a header-only library now

But there's one thing I'm not happy about it but I couldn't figure out how to do without:

64775c700ab33f65fe4e30612a2f48cf5c726ad8

I simply removed the embedded vcpkg in favor of my own in c:\vcpkg, this is because I haven't been able to get the embedded one to detect the VS2022 installation.
